### PR TITLE
Update channels-logos-picons ebuild

### DIFF
--- a/x11-themes/channel-logos-picons/channel-logos-picons-9999.ebuild
+++ b/x11-themes/channel-logos-picons/channel-logos-picons-9999.ebuild
@@ -22,7 +22,7 @@ S=${WORKDIR}
 RRDEPEND="${DEPEND}"
 
 src_install() {
-	dodoc README.md VERSION
+	dodoc README.md
 	chmod ugo+x picons.sh
 	./picons.sh picons
 	insinto "${CHANLOGOBASE}/${LOGOPACKNAME}"


### PR DESCRIPTION
VERSION file does not exist in picons repo.
